### PR TITLE
fix: update how path to elm binary is resolved

### DIFF
--- a/bin/elm-app-cli.js
+++ b/bin/elm-app-cli.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+
 const path = require('path');
 const spawn = require('cross-spawn');
 const argv = require('minimist')(process.argv.slice(2));
@@ -61,7 +62,7 @@ switch (script) {
 
     args = args.concat([
       '--compiler',
-      path.join(path.dirname(require.resolve('elm')), '/unpacked_bin/elm')
+      require.resolve('elm/bin/elm')
     ]);
     const cp = spawn.sync(require.resolve('elm-test/bin/elm-test'), args, {
       stdio: 'inherit'


### PR DESCRIPTION
BREAKING CHANGE: create-elm-app does guarantee backward compatibility of all underlying dependencies
so this release is marked as breaking

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
